### PR TITLE
Specify a relative path for mobile-isomdl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ jna-*.jar
 kotlin/mobilesdkrs/src/main/java/com/spruceid/mobile/sdk/rs/mobile_sdk_rs.kt
 kotlin/mobilesdkrs/src/main/jniLibs/*
 kotlin/local.properties
+Cargo.lock
 .direnv
 .envrc
 **.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "uniffi-bindgen.rs"
 cose-rs = { git = "https://github.com/spruceid/cose-rs", rev = "0018c9b", features = [
     "time",
 ] }
-isomdl = { path = "/Users/iancarbone/Documents/Development/SpruceID/AQSpruce/mobile-isomdl" }
+isomdl = { path = "../mobile-isomdl" }
 oid4vci = { git = "https://github.com/spruceid/oid4vci-rs", rev = "e97b01e" }
 openid4vp = { git = "https://github.com/spruceid/openid4vp", rev = "2212f78" }
 ssi = { version = "0.10.2", features = ["secp256r1", "secp384r1"] }


### PR DESCRIPTION
Previously the path was hard-coded to an absolute checked out path